### PR TITLE
feat: add support for configuration-path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,3 +81,49 @@ jobs:
         run: |
           set -x
           test "${OUTCOME}" = "failure"
+
+  test-configuration-path:
+    name: Test configuration-path
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: tmknom/checkout-action@v1
+
+      - name: Setup
+        id: setup
+        run: |
+          set -x
+          workflow_file=".github/workflows/${GITHUB_JOB}_${GITHUB_RUN_ID}.yml"
+          rm -f "${workflow_file}"
+          cat <<EOF > "${workflow_file}"
+          name: invalid
+          on:
+            workflow_dispatch:
+          EOF
+
+          config_file="actionlint.yml"
+          rm -f "${config_file}"
+          cat <<EOF >"${config_file}"
+          paths:
+            ${workflow_file}:
+              ignore:
+                - '"jobs" section is missing in workflow'
+          EOF
+          echo "path=${config_file}" >> "${GITHUB_OUTPUT}"
+
+      - name: Exercise
+        id: exercise
+        uses: ./
+        with:
+          configuration-path: ${{ steps.setup.outputs.path }}
+        continue-on-error: true
+
+      - name: Verify
+        env:
+          OUTCOME: ${{ steps.exercise.outcome }}
+        run: |
+          set -x
+          test "${OUTCOME}" = "success"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ To achieve this, it enforces strict container isolation, disables network connec
 
 ## Inputs
 
-N/A
+| Name | Description | Default | Required |
+| :--- | :---------- | :------ | :------: |
+| configuration-path | The path for the actionlint configurations. | n/a | no |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,11 @@ description: |
         uses: tmknom/secure-actionlint-action@v0
   ```
 
+inputs:
+  configuration-path:
+    required: false
+    description: The path for the actionlint configurations.
+
 runs:
   using: composite
 
@@ -40,13 +45,19 @@ runs:
 
     - name: Run
       env:
+        CONFIG_PATH: ${{ inputs.configuration-path }}
         IMAGE: ${{ steps.install.outputs.image }}
       run: |
         echo "::group::Run"
         set -x
+        declare -a flags=(-color)
+        if [[ "${CONFIG_PATH}" != "" ]]; then
+          flags+=(-config-file "${CONFIG_PATH}")
+        fi
+
         docker run --interactive --rm --read-only --user guest \
           --security-opt no-new-privileges --cap-drop all --network none \
           --volume "${PWD}:${PWD}" --workdir "${PWD}" \
-          "${IMAGE}" --color
+          "${IMAGE}" "${flags[@]}"
         echo "::endgroup::"
       shell: bash


### PR DESCRIPTION
- Updated the `Run` step to accept and handle the `configuration-path` input.
- Added logic to dynamically include the `-config-file` flag when a configuration path is provided.
- Ensured the Docker container mounts the current working directory for proper file access.
- Improved flexibility by allowing users to specify custom actionlint configurations.
